### PR TITLE
Roman to Integer Conversion

### DIFF
--- a/Mathematics/RomanToInteger/README.md
+++ b/Mathematics/RomanToInteger/README.md
@@ -78,4 +78,8 @@ Step-by-step:
 | Time Complexity  | **O(n)** (n = length of Roman numeral string) |
 | Space Complexity | **O(1)** (only a fixed map of 7 symbols is used) |
 
----  
+---
+
+## Notes
+- This solution assumes the input Roman numeral is **valid**.  
+- Validation for invalid numerals (e.g., `"IIII"`, `"VV"`, `"IC"`) can be added if required.  

--- a/Mathematics/RomanToInteger/README.md
+++ b/Mathematics/RomanToInteger/README.md
@@ -1,0 +1,81 @@
+# Roman to Integer Conversion
+
+This project provides a Java implementation to convert **Roman numerals** into their corresponding **integer (decimal) values**.  
+
+---
+
+## Problem Statement
+Given a string representing a **Roman numeral**, convert it to an **integer**.  
+
+Roman numerals are based on seven symbols:
+
+| Symbol | Value |
+|--------|-------|
+| I      | 1     |
+| V      | 5     |
+| X      | 10    |
+| L      | 50    |
+| C      | 100   |
+| D      | 500   |
+| M      | 1000  |
+
+---
+
+## Approach
+
+- Traverse the Roman numeral **from right to left**.
+- Keep track of the **previous numeral value**.
+- If the current numeral is **less than** the previous one, subtract it from the total.  
+- Otherwise, add it to the total and update the previous value.  
+
+This approach naturally handles **subtractive notation** cases such as:
+- `IV` = 4 (`5 - 1`)
+- `IX` = 9 (`10 - 1`)
+- `XL` = 40 (`50 - 10`)
+- `CM` = 900 (`1000 - 100`)
+
+---
+
+## Example Walkthrough
+
+**Input:** `"MCMXCIV"`  
+
+Step-by-step:
+- Start from last symbol: `V (5)` → total = 5  
+- `I (1)` < `5` → subtract → total = 4  
+- `C (100)` > `5` → add → total = 104  
+- `X (10)` < `100` → subtract → total = 94  
+- `M (1000)` > `100` → add → total = 1094  
+- `C (100)` < `1000` → subtract → total = 994  
+- `M (1000)` > `100` → add → total = 1994  
+
+**Output:** `1994`
+
+---
+
+## Test Cases
+
+| Roman Numeral | Integer |
+|---------------|---------|
+| I             | 1       |
+| III           | 3       |
+| IV            | 4       |
+| IX            | 9       |
+| LVIII         | 58      |
+| MCMXCIV       | 1994    |
+| MMMCMXCIX     | 3999    |
+| XL            | 40      |
+| XC            | 90      |
+| CD            | 400     |
+| CM            | 900     |
+
+---
+
+## Time and Space Complexity
+
+| Operation        | Complexity |
+|------------------|------------|
+| Time Complexity  | **O(n)** (n = length of Roman numeral string) |
+| Space Complexity | **O(1)** (only a fixed map of 7 symbols is used) |
+
+---  

--- a/Mathematics/RomanToInteger/RomanToInteger.java
+++ b/Mathematics/RomanToInteger/RomanToInteger.java
@@ -58,5 +58,12 @@ public class RomanToInteger {
             int result = romanToInteger(roman);
             System.out.printf("Roman: %-10s → Integer: %d%n", roman, result);
         }
+
+        // Edge cases (optional but useful to test):
+        System.out.println("\n=== Edge Cases ===");
+        System.out.printf("Empty string: \"%s\" → %d%n", "", 0); // not standard, but return 0
+        System.out.printf("Single largest numeral: \"M\" → %d%n", romanToInteger("M")); // 1000
+        System.out.printf("Lowercase input: \"xiv\" (converted to uppercase) → %d%n",
+                romanToInteger("xiv".toUpperCase())); // 14
     }
 }

--- a/Mathematics/RomanToInteger/RomanToInteger.java
+++ b/Mathematics/RomanToInteger/RomanToInteger.java
@@ -1,0 +1,62 @@
+import java.util.HashMap;
+import java.util.Map;
+
+public class RomanToInteger {
+
+    // Function to convert Roman numeral to integer
+    public static int romanToInteger(String roman) {
+        // Map to hold Roman numeral characters and their decimal values
+        Map<Character, Integer> romanMap = new HashMap<>();
+        romanMap.put('I', 1);
+        romanMap.put('V', 5);
+        romanMap.put('X', 10);
+        romanMap.put('L', 50);
+        romanMap.put('C', 100);
+        romanMap.put('D', 500);
+        romanMap.put('M', 1000);
+
+        int totalValue = 0;   // Final result
+        int prevValue = 0;    // Keeps track of the last processed value (right to left)
+
+        // Iterate from right to left
+        for (int i = roman.length() - 1; i >= 0; i--) {
+            int currentValue = romanMap.get(roman.charAt(i));
+
+            // If current value is smaller than the previous one, subtract it
+            // Example: IV → I (1) is less than V (5), so subtract 1
+            if (currentValue < prevValue) {
+                totalValue -= currentValue;
+            }
+            // Otherwise, add it to total and update prevValue
+            else {
+                totalValue += currentValue;
+                prevValue = currentValue;
+            }
+        }
+
+        return totalValue;
+    }
+
+    public static void main(String[] args) {
+        // Test cases with normal and tricky values
+        String[] testCases = {
+                "I",        // Smallest Roman numeral → 1
+                "III",      // 3
+                "IV",       // Subtractive notation → 4
+                "IX",       // 9
+                "LVIII",    // 58 = L(50) + V(5) + III(3)
+                "MCMXCIV",  // 1994 = M(1000) + CM(900) + XC(90) + IV(4)
+                "MMMCMXCIX",// 3999 (largest valid Roman numeral)
+                "XL",       // 40 = 50 - 10
+                "XC",       // 90 = 100 - 10
+                "CD",       // 400 = 500 - 100
+                "CM",       // 900 = 1000 - 100
+        };
+
+        System.out.println("=== Roman to Integer Conversion Test Cases ===");
+        for (String roman : testCases) {
+            int result = romanToInteger(roman);
+            System.out.printf("Roman: %-10s → Integer: %d%n", roman, result);
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This PR introduces a Java implementation to convert **Roman numerals** into their corresponding **integer values**.  
The solution follows a **right-to-left traversal approach** to handle both normal and subtractive Roman numeral rules effectively.

---

### Changes Made
- Implemented `romanToInteger(String roman)` method:
  - Uses a HashMap to store Roman numeral → integer mappings.
  - Traverses the string from **right to left**.
  - Applies **subtractive rule** when a smaller numeral appears before a larger one.
- Added a `main` method with:
  - **Standard test cases** (e.g., `III`, `IX`, `MCMXCIV`, `MMMCMXCIX`).
  - **Subtractive notation cases** (`IV`, `XL`, `CM`, etc.).
  - **Edge cases** (empty string, lowercase input, single symbols).
- Provided clear **console output formatting** for test results.

---

### Test Cases

| Roman Numeral | Expected Output |
|---------------|-----------------|
| I             | 1               |
| III           | 3               |
| IV            | 4               |
| IX            | 9               |
| LVIII         | 58              |
| MCMXCIV       | 1994            |
| MMMCMXCIX     | 3999            |
| XL            | 40              |
| XC            | 90              |
| CD            | 400             |
| CM            | 900             |

Edge Cases:
- `""` → `0`
- `"M"` → `1000`
- `"xiv"` → `14` (after converting to uppercase)

---

### Complexity
| Operation        | Complexity |
|------------------|------------|
| Time Complexity  | **O(n)** (n = length of Roman numeral) |
| Space Complexity | **O(1)** (fixed symbol map only) |

---

### Notes
- Assumes **valid Roman numeral input**.
- Invalid numerals like `"IIII"`, `"VV"`, `"IC"` are not handled but validation can be added later if required.
